### PR TITLE
Added new IdP for CascadiaCC to work with their MS ADFS SAML IdP impl…

### DIFF
--- a/uw_saml2/idp/federated.py
+++ b/uw_saml2/idp/federated.py
@@ -3,15 +3,18 @@ from . import IdpConfig, attribute
 
 
 class CascadiaIdp(IdpConfig):
-    #  Added this class to address new Cascadia IdP. Some parts may still need to be udpated.
-    #  entityID and sso_url from CCFederationMetadata.xml, which was supplied by Cascadia.
-    #  _attribute_prefix and id_attribute from FredHutchAzureIdp(IdpConfig) in this file
-    #  x509_cert from CCFederationMetadata.xml IDPSSODescriptor/KeyDescriptor/signing
+    #  Added this class to address new Cascadia IdP.
+    #  Some parts may still need to be udpated.
+    #  entityID and sso_url from CCFederationMetadata.xml, from Cascadia.
+    #  _attribute_prefix, id_attribute from FredHutchAzureIdp(IdpConfig)
+    #  x509_cert from
+    #  CCFederationMetadata.xml IDPSSODescriptor/KeyDescriptor/signing
     entityID = 'http://sts.cascadia.edu/adfs/services/trust'
     sso_url = 'https://sts.cascadia.edu/adfs/ls/'
     _attribute_prefix = 'http://schemas.xmlsoap.org/ws/2005/05/identity/claims'
     id_attribute = f'{_attribute_prefix}/employeeid'
-    x509_cert = '''  
+    _idp_url = 'https://idp.employee.cascadia.edu'
+    x509_cert = '''
         MIIC3DCCAcSgAwIBAgIQY8aKwjLQ9pRPN0sUxfcQoDANBgkqhkiG9w0BAQsFADAq
         MSgwJgYDVQQDEx9BREZTIFNpZ25pbmcgLSBzdHMuY2FzY2FkaWEuZWR1MB4XDTE5
         MDUwMTE4NTQxMloXDTIwMDQzMDE4NTQxMlowKjEoMCYGA1UEAxMfQURGUyBTaWdu


### PR DESCRIPTION
…emenatation. At the point it is really in a test phase.

This is only one part of the changes needed to add Cascadia's new IdP.
@jdiverp and I had to make educated guesses for `_attribute_prefix`, `id_attribute`, 
`x509_cert` is also a little uncertain as there were a few values for it in the supplied XML.

Another part to this change will be in the **identity-uw** repo to utilize the new IdP.