### PR TITLE
Update version to 1.2 since we are breaking backwards compatability.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "uw-saml"
-version = "1.1.1"
+version = "1.2.0"
 description = "A UW-specific adapter to the python3-saml package."
 authors = []
 license = "Apache 2.0"


### PR DESCRIPTION
**Change Description:** Just updating the version manually, the automation pipeline broke down a little...

## uw-saml-python Pull Request checklist

- [x] I have run `./scripts/pre-push.sh`
- [x] I have selected a `semver-guidance:` label for this pull request (under labels,
      to the right of the screen)

If you do not do both of these things, your checks will either not run, or have a high probability of failing.
