### PR TITLE
[GH-49] Add security object with requestedAuthnContext to include password and x509 to AzureIdPs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "uw-saml"
-version = "1.2.4"
+version = "1.2.5"
 description = "A UW-specific adapter to the python3-saml package."
 authors = []
 license = "Apache 2.0"

--- a/uw_saml2/idp/federated.py
+++ b/uw_saml2/idp/federated.py
@@ -66,6 +66,12 @@ class CascadiaAzureIdp(IdpConfig):
         wJPxARowqyxR5q6PWX5JzOtFzuCx0vJ/jI0o8iAg53fOitgDFj3E6/qxjPhoDY+Q
         Pq4dr8god4m9Nr6k8kFWBbL2sXn1GC72SDeuvk0Q4X3t8tLb
     """
+    security = {
+        "requestedAuthnContext": [
+            "urn:oasis:names:tc:SAML:2.0:ac:classes:Password",
+            "urn:oasis:names:tc:SAML:2.0:ac:classes:X509",
+        ]
+    }
 
 
 class CollegenetIdp(IdpConfig):
@@ -140,6 +146,12 @@ class FredHutchAzureIdp(IdpConfig):
         fMU1NZFfOfsaDjM18iSBDcsYIDeSadDh8knyFRxYGXHYrifEEq5qZBgnXXhYZLse
         4BimG9X9nynGlI6QcU5Qj7gnddQOQpk2OFFAGoUBw+vQaZNZLDGGcyvbRaueuXSh
         4gzm/WDtjnJ/Cod/Qg8OfJLEARBkLQZpvCFlTDFJ1dkDDRMC"""
+    security = {
+        "requestedAuthnContext": [
+            "urn:oasis:names:tc:SAML:2.0:ac:classes:Password",
+            "urn:oasis:names:tc:SAML:2.0:ac:classes:X509",
+        ]
+    }
 
 
 class SccaIdp(IdpConfig):


### PR DESCRIPTION
**Change Description:** Fix Azure SAML authentications for Cascadia and FHCC (not UW Tenant) not working with Identity.UW because Azure returns "X509, MultiFactor" instead of "Password protected transport" 

**Closes Github Issues**: 
GH-49

## uw-saml-python Pull Request checklist

- [x] I have run `./scripts/pre-push.sh`
- [x] I have selected a `semver-guidance:` label for this pull request (under labels,
      to the right of the screen)

If you do not do both of these things, your checks will either not run, or have a high probability of failing.
