### PR TITLE
Revert uw-saml-pyton back to where it was before I tried to fix Azure…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "uw-saml"
-version = "1.2.6"
+version = "1.2.7"
 description = "A UW-specific adapter to the python3-saml package."
 authors = []
 license = "Apache 2.0"

--- a/uw_saml2/idp/federated.py
+++ b/uw_saml2/idp/federated.py
@@ -66,7 +66,6 @@ class CascadiaAzureIdp(IdpConfig):
         wJPxARowqyxR5q6PWX5JzOtFzuCx0vJ/jI0o8iAg53fOitgDFj3E6/qxjPhoDY+Q
         Pq4dr8god4m9Nr6k8kFWBbL2sXn1GC72SDeuvk0Q4X3t8tLb
     """
-    security = {"requestedAuthnContext": True}
 
 
 class CollegenetIdp(IdpConfig):
@@ -141,7 +140,6 @@ class FredHutchAzureIdp(IdpConfig):
         fMU1NZFfOfsaDjM18iSBDcsYIDeSadDh8knyFRxYGXHYrifEEq5qZBgnXXhYZLse
         4BimG9X9nynGlI6QcU5Qj7gnddQOQpk2OFFAGoUBw+vQaZNZLDGGcyvbRaueuXSh
         4gzm/WDtjnJ/Cod/Qg8OfJLEARBkLQZpvCFlTDFJ1dkDDRMC"""
-    security = {"requestedAuthnContext": True}
 
 
 class SccaIdp(IdpConfig):


### PR DESCRIPTION
…Idp issues.

**Change Description:**  this code released did not work as intended for this fix.

**Closes Github issues**: GH-52

## uw-saml-python Pull Request checklist

- [x] I have run `./scripts/pre-push.sh`
- [x] I have selected a `semver-guidance:` label for this pull request (under labels,
      to the right of the screen)

If you do not do both of these things, your checks will either not run, or have a high probability of failing.
