### PR TITLE
[GH-49] Fix Azure tenants by enabling requests for both Password and X509 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "uw-saml"
-version = "1.2.7"
+version = "1.2.8"
 description = "A UW-specific adapter to the python3-saml package."
 authors = []
 license = "Apache 2.0"

--- a/uw_saml2/idp/federated.py
+++ b/uw_saml2/idp/federated.py
@@ -66,6 +66,7 @@ class CascadiaAzureIdp(IdpConfig):
         wJPxARowqyxR5q6PWX5JzOtFzuCx0vJ/jI0o8iAg53fOitgDFj3E6/qxjPhoDY+Q
         Pq4dr8god4m9Nr6k8kFWBbL2sXn1GC72SDeuvk0Q4X3t8tLb
     """
+    multi_authn_context_x509 = True
 
 
 class CollegenetIdp(IdpConfig):
@@ -140,6 +141,7 @@ class FredHutchAzureIdp(IdpConfig):
         fMU1NZFfOfsaDjM18iSBDcsYIDeSadDh8knyFRxYGXHYrifEEq5qZBgnXXhYZLse
         4BimG9X9nynGlI6QcU5Qj7gnddQOQpk2OFFAGoUBw+vQaZNZLDGGcyvbRaueuXSh
         4gzm/WDtjnJ/Cod/Qg8OfJLEARBkLQZpvCFlTDFJ1dkDDRMC"""
+    multi_authn_context_x509 = True
 
 
 class SccaIdp(IdpConfig):

--- a/uw_saml2/idp/uw.py
+++ b/uw_saml2/idp/uw.py
@@ -39,6 +39,10 @@ class UwIdp(IdpConfig):
     }
 
 
+class MultiAuthnContextX509(UwIdp):
+    mfazure_factor = True
+
+
 class UwIdpTwoFactor(UwIdp):
     two_factor = True
 

--- a/uw_saml2/sp.py
+++ b/uw_saml2/sp.py
@@ -2,6 +2,9 @@
 from urllib.parse import urlparse
 import os
 
+MULTI_AUTHN_CONTEXT_X509 = ["urn:oasis:names:tc:SAML:2.0:ac:classes:Password",
+                            "urn:oasis:names:tc:SAML:2.0:ac:classes:X509"]
+
 TWO_FACTOR_CONTEXT = "https://refeds.org/profile/mfa"
 
 
@@ -46,7 +49,7 @@ class Config(object):
     def key(self):
         return self._read_file(self.key_file)
 
-    def config(self, idp, two_factor=False):
+    def config(self, idp, two_factor=False, mfazure_factor=False):
         """Return config in a way that makes sense to OneLogin_Saml2_Auth."""
         data = {
             "strict": True,
@@ -74,4 +77,15 @@ class Config(object):
                     }
                 }
             )
+
+        if mfazure_factor or getattr(idp, "multi_authn_context_x509", False):
+            data.update(
+                {
+                    "security": {
+                        "requestedAuthnContext": MULTI_AUTHN_CONTEXT_X509,
+                        "failOnAuthnContextMismatch": True,
+                    }
+                }
+            )
+
         return data

--- a/uw_saml2/sp.py
+++ b/uw_saml2/sp.py
@@ -2,8 +2,10 @@
 from urllib.parse import urlparse
 import os
 
-MULTI_AUTHN_CONTEXT_X509 = ["urn:oasis:names:tc:SAML:2.0:ac:classes:Password",
-                            "urn:oasis:names:tc:SAML:2.0:ac:classes:X509"]
+MULTI_AUTHN_CONTEXT_X509 = [
+    "urn:oasis:names:tc:SAML:2.0:ac:classes:Password",
+    "urn:oasis:names:tc:SAML:2.0:ac:classes:X509",
+]
 
 TWO_FACTOR_CONTEXT = "https://refeds.org/profile/mfa"
 


### PR DESCRIPTION
**Change Description:** 
See
https://github.com/UWIT-IAM/identity-uw/issues/612 and
https://github.com/UWIT-IAM/uw-saml-python/issues/49

**Closes Github Issues**: 
uw-saml-python's [GH-49](https://github.com/UWIT-IAM/uw-saml-python/issues/49)
identity's [GH-612](https://github.com/UWIT-IAM/identity-uw/issues/612)


## uw-saml-python Pull Request checklist

- [x] I have run `./scripts/pre-push.sh`
- [x] I have selected a `semver-guidance:` label for this pull request (under labels,
      to the right of the screen)

If you do not do both of these things, your checks will either not run, or have a high probability of failing.
