### PR TITLE
GH-fix-GH-58 use newer python version in release process

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -19,10 +19,10 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install poetry
         run: pipx install poetry
-      - name: Set up Python 3.8
+      - name: Set up Python 3.10
         uses: actions/setup-python@v4
         with:
-          python-version: "3.8"
+          python-version: "3.10"
       - run: poetry config pypi-token.pypi ${{ secrets.PYPI_TOKEN }}
       - with:
           project_id: ${{ secrets.IAM_GCR_REPO }}

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -10,7 +10,6 @@ env:
   workflow_url: >
     https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
   dry_run: ${{ github.ref != 'refs/heads/main' }}
-  SLACK_BOT_TOKEN: ${{ secrets.ACTIONS_SLACK_BOT_TOKEN }}
   GCLOUD_TOKEN: ${{ secrets.GCR_TOKEN }}
 
 jobs:
@@ -36,58 +35,8 @@ jobs:
           echo "::set-output name=short-sha::${GITHUB_SHA:0:10}"
         id: configure
 
-      - uses: uwit-iam/actions/set-up-slack-notification-canvas@0.1.18
-        id: create-canvas
-        env:
-          description_prefix: ${{ env.dry_run && '[DRY RUN] ' || '' }}
-        with:
-          json: >
-            {
-              "description": "${{ env.description_prefix }}${{ github.workflow }}",
-              "status": "in progress",
-              "channel": "#iam-bots",
-              "steps": [
-                {
-                  "description": "Configure <${{ env.workflow_url }} | workflow>",
-                  "status": "succeeded",
-                  "stepId": "configure"
-                },
-                {
-                  "description": "Run tests",
-                  "status": "in progress",
-                  "stepId": "run-tests"
-                },
-                {
-                  "description": "Release version ${{ steps.configure.outputs.version }}",
-                  "stepId": "release"
-                }
-              ]
-            }
-
-      - uses: uwit-iam/actions/update-slack-workflow-canvas@0.1.18
-        if: steps.create-canvas.outputs.canvas-id
-        env:
-          commit_url: >
-            https://github.com/${{ github.repository }}/commit/${{ github.sha }}
-        with:
-          command: add-artifact
-          description: >
-            <${{ env.workflow_url }} | Workflow> triggered by ${{ github.actor }}
-            from a ${{ github.event_name }} at
-            <${{ env.commit_url }} | commit ${{ steps.configure.outputs.short-sha }}>
-
       - run: ./scripts/pre-push.sh --check-only
         id: run-tests
-
-      - if: always() && steps.create-canvas.outputs.canvas-id
-        uses: uwit-iam/actions/update-slack-workflow-canvas@0.1.18
-        env:
-          test-status: ${{ steps.run-tests.outcome == 'success' && 'succeeded' || 'failed' }}
-          release-status: ${{ steps.run-tests.outcome == 'success' && 'in progress' || 'not started' }}
-        with:
-          command: update-workflow
-          step-id: run-tests, release
-          step-status: ${{ env.test-status }}, ${{ env.release-status }}
 
       - uses: ncipollo/release-action@v1.8.6
         if: ${{ ! env.dry_run }}
@@ -97,25 +46,9 @@ jobs:
           commit: ${{ github.sha }}
           tag: ${{ steps.configure.outputs.version }}
 
-      - uses: uwit-iam/actions/update-slack-workflow-canvas@0.1.18
-        if: success() && steps.create-canvas.outputs.canvas-id
-        env:
-          release_version: ${{ steps.configure.outputs.version }}
-          release_url: ${{ steps.create-release.outputs.html_url || 'https://www.example.com' }}
-          action_desc: ${{ env.dry_run == 'true' && 'Dry-run for' || 'Published' }}
-        with:
-          command: add-artifact
-          description: >
-            ${{ env.action_desc }} release
-            <${{ env.release_url }} | ${{ env.release_version }}>
       - run: |
           set -x
           poetry publish \
             --build \
             $(test "${{ env.dry_run }}" == "false" || echo "--dry-run")
         id: publish-release
-
-      - if: always() && steps.create-canvas.outputs.canvas-id
-        uses: uwit-iam/actions/finalize-slack-notification-canvas@0.1.18
-        with:
-          workflow-status: ${{ job.status == 'failure' && 'failed' || 'succeeded' }}

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -19,10 +19,10 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install poetry
         run: pipx install poetry
-      - name: Set up Python 3.10
+      - name: Set up Python 3.12
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.12"
       - run: poetry config pypi-token.pypi ${{ secrets.PYPI_TOKEN }}
       - with:
           project_id: ${{ secrets.IAM_GCR_REPO }}


### PR DESCRIPTION
**Change Description:** fix setuptools with newer python version. This is still related to getting uw-saml-python 1.2.9 released into pypi.

## uw-saml-python Pull Request checklist

- [x] I have run `./scripts/pre-push.sh`
- [x] I have selected a `semver-guidance:` label for this pull request (under labels,
      to the right of the screen)

If you do not do both of these things, your checks will either not run, or have a high probability of failing.
